### PR TITLE
[Fixed] `rails g` Empêcher les fichiers d'aide et de ressources d'être générés par défaut.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,12 +8,10 @@ Bundler.require(*Rails.groups)
 module FacebookClone
   class Application < Rails::Application
     config.exceptions_app = self.routes
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
#1 

Empêcher les fichiers d'aide et de ressources d'être générés par défaut lorsqu'on utilise la commande rails g